### PR TITLE
throw clear Exception

### DIFF
--- a/src/Arabic.php
+++ b/src/Arabic.php
@@ -3872,11 +3872,15 @@ class Arabic
      * @param string  $plural3  Plural form 3 (e.g., عناصر). If NULL [default] retrive from internal JSON dataset.
      * @param string  $plural4  Plural form 4 (e.g., عنصرا). If NULL [default] retrive from internal JSON dataset.
      *
-     * @return string Proper plural form of the given singular form
+     * @return string|\Exception Proper plural form of the given singular form, throw exiption if the $singular is not pre defiend and $plural is not passed
      * @author Khaled Al-Sham'aa <khaled@ar-php.org>
      */
     public function arPlural($singular, $count, $plural2 = null, $plural3 = null, $plural4 = null)
     {
+        if(!array_key_exists($singular, $this->arPluralsForms)){
+            throw new \Exception("Please Provide all plural forms for the word: $singular.");
+        }
+
         if ($count == 0) {
             $plural = is_null($plural2) ? $this->arPluralsForms[$singular][0] : "لا $plural3";
         } elseif ($count == 1) {


### PR DESCRIPTION
Throw an exception if the `$singular` is not **pre-defined** and `$plural` is not passed.

It gives a clear message about the issue instead of the default PHP `Undefined index` massage.

before:
![Screen Shot 2021-05-08 at 9 00 38 PM](https://user-images.githubusercontent.com/1952412/117548968-77d86d00-b040-11eb-8e7e-e5df934b4faf.png)

after:
![Screen Shot 2021-05-08 at 9 00 25 PM](https://user-images.githubusercontent.com/1952412/117548967-773fd680-b040-11eb-9d5b-d92c5d2dd729.png)


