### PR TITLE
fix: missing field REGEXP in getWordRegExp()

### DIFF
--- a/src/Arabic.php
+++ b/src/Arabic.php
@@ -3371,8 +3371,11 @@ class Arabic
     {
         $arg = $this->arQueryLex($arg);
         $argLike = preg_replace('/\(([^()]|(?R))*\)\??/', '', $arg);
-        $sql = implode(" LIKE '%$argLike%' AND REGEXP '$arg') OR (", $this->arQueryFields) .
-               " LIKE '%$argLike%' AND REGEXP '$arg'";
+        $parts = [];
+        foreach ($this->arQueryFields as $field) {
+            $parts[] = "$field LIKE '%$argLike%' AND $field REGEXP '$arg'";
+        }
+        $sql = implode(' OR ', $parts);
         /*
         $sql = ' REPLACE(' . implode(", 'ـ', '') REGEXP '$arg' OR REPLACE(", $this->arQueryFields) .
                ", 'ـ', '') REGEXP '$arg'";

--- a/src/Arabic.php
+++ b/src/Arabic.php
@@ -3363,17 +3363,22 @@ class Arabic
      * REGEXP clause and lex's rules
      *
      * @param string $arg String (one word) that you want to build a condition for
+     * @param when true combine LIKE and REGEXP; when false use REGEXP only
      *
      * @return string sub SQL condition (for internal use)
      * @author Khaled Al-Sham'aa <khaled@ar-php.org>
      */
-    private function getWordRegExp($arg)
+    private function getWordRegExp($arg, $useLike = false) 
     {
         $arg = $this->arQueryLex($arg);
         $argLike = preg_replace('/\(([^()]|(?R))*\)\??/', '', $arg);
         $parts = [];
         foreach ($this->arQueryFields as $field) {
-            $parts[] = "$field LIKE '%$argLike%' AND $field REGEXP '$arg'";
+            if ($useLike) {
+                $parts[] = "$field LIKE '%$argLike%' AND $field REGEXP '$arg'";
+            } else {
+                $parts[] = "$field REGEXP '$arg'";
+            }
         }
         $sql = implode(' OR ', $parts);
         /*


### PR DESCRIPTION
Current Behavior builds a where condition like this
`WHERE (field LIKE '%فلسطيني%' AND REGEXP '((ا|أ|إ|آ)ل)?فلسطيني(ون)?')`
This throws and error, because its invalid SQL `REGEXP` must be preceded by a field name.

This PR fixes it by appending it like this:
`WHERE (field LIKE '%فلسطيني%' AND field REGEXP '((ا|أ|إ|آ)ل)?فلسطيني(ون)?')`

Thank you for all the great work on this project 🙏❤️